### PR TITLE
Update platform.h

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -104,7 +104,7 @@ constexpr uint8_t VALUE_IPL { (microsecondsToClockCycles(1) > 120) ? 26 : 22 }; 
 #define DIRECT_MODE_OUTPUT(base, pin)   pinMode(pin,OUTPUT)
 #define DELAY_MICROSECONDS(us)		    delayMicroseconds(us)
 using io_reg_t = uint32_t; // define special data type for register-access
-constexpr uint8_t VALUE_IPL { 39 }; // instructions per loop, for 40 and 80 MHz (see esp8266 difference)
+constexpr uint8_t VALUE_IPL { 51 }; // instructions per loop, for 40 and 80 MHz (see esp8266 difference), was 39
 
 #elif defined(ARDUINO_ARCH_SAMD) /* arduino family samd */
 // arduino-zero is defined(__SAMD21G18A__)


### PR DESCRIPTION
Reset pulse width was 1.3ms, now it's 1.0ms for ESP32, #https://github.com/orgua/OneWireHub/issues/102#issuecomment-1500928478